### PR TITLE
Don't treat POSITION1 as index stream.

### DIFF
--- a/MarathonRecomp/gpu/video.cpp
+++ b/MarathonRecomp/gpu/video.cpp
@@ -5207,10 +5207,6 @@ static GuestVertexDeclaration* CreateVertexDeclarationWithoutAddRef(GuestVertexE
                 }
 
                 break;
-            case D3DDECLUSAGE_POSITION:
-                if (vertexElement->usageIndex == 1)
-                    vertexDeclaration->indexVertexStream = vertexElement->stream;
-                break;
 
             case D3DDECLUSAGE_TEXCOORD:
                 switch (vertexElement->type)


### PR DESCRIPTION
This was specific to Unleashed and is causing stream 1 to get unset for morph shaders.