### PR TITLE
Let recompiler output status during recompile.

### DIFF
--- a/MarathonRecompLib/CMakeLists.txt
+++ b/MarathonRecompLib/CMakeLists.txt
@@ -33,6 +33,7 @@ add_custom_command(
     DEPENDS 
         "${CMAKE_CURRENT_SOURCE_DIR}/private/default.xex"
         "${CMAKE_CURRENT_SOURCE_DIR}/config/Marathon.toml"
+    USES_TERMINAL
 )
 
 add_custom_command(
@@ -70,6 +71,7 @@ add_custom_command(
         "${CMAKE_CURRENT_SOURCE_DIR}/private/shader"
         ${XENOS_RECOMP_SOURCES}
         ${XENOS_RECOMP_INCLUDE}
+    USES_TERMINAL
 )
 
 add_library(MarathonRecompLib


### PR DESCRIPTION
Adds CMake hints to let the recompilers output status to terminal during recompilation instead of after, so the progress messages are actually useful.