### PR TITLE
Remove leftover UnleashedRecomp calls when available

### DIFF
--- a/MarathonRecomp/kernel/xam.cpp
+++ b/MarathonRecomp/kernel/xam.cpp
@@ -227,7 +227,7 @@ uint32_t XamShowMessageBoxUI(uint32_t dwUserIndex, be<uint16_t>* wszTitle, be<ui
 
     wprintf(L"[XamShowMessageBoxUI] !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n");
     wprintf(L"[XamShowMessageBoxUI] If you are encountering this message and the game has ceased functioning,\n");
-    wprintf(L"[XamShowMessageBoxUI] please create an issue at https://github.com/hedge-dev/UnleashedRecomp/issues.\n");
+    wprintf(L"[XamShowMessageBoxUI] please create an issue at https://github.com/sonicnext-dev/MarathonRecomp/issues.\n");
     wprintf(L"[XamShowMessageBoxUI] !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n");
     wprintf(L"[XamShowMessageBoxUI] %ls\n", texts[0].c_str());
     wprintf(L"[XamShowMessageBoxUI] %ls\n", texts[1].c_str());

--- a/MarathonRecomp/os/win32/registry_win32.inl
+++ b/MarathonRecomp/os/win32/registry_win32.inl
@@ -1,6 +1,6 @@
 #include <os/registry.h>
 
-inline const wchar_t* g_registryRoot = L"Software\\UnleashedRecomp";
+inline const wchar_t* g_registryRoot = L"Software\\MarathonRecomp";
 
 inline bool os::registry::Init()
 {

--- a/MarathonRecomp/ui/game_window.cpp
+++ b/MarathonRecomp/ui/game_window.cpp
@@ -157,7 +157,7 @@ int Window_OnSDLEvent(void*, SDL_Event* event)
 void GameWindow::Init(const char* sdlVideoDriver)
 {
 #ifdef __linux__
-    SDL_SetHint("SDL_APP_ID", "io.github.sonicnext_dev.unleashedrecomp");
+    SDL_SetHint("SDL_APP_ID", "io.github.sonicnext_dev.marathonrecomp");
 #endif
 
     if (SDL_VideoInit(sdlVideoDriver) != 0 && sdlVideoDriver)


### PR DESCRIPTION
This pull request aims to replace some leftover UnleashedRecomp mentions and calls within the codebase. (I.E within the Registry)
It's unknown if the stuff within this pull request would impact the game in any capacity so it is set up as a draft for now.