### PR TITLE
Update XenosRecomp and shared constants to fix D3D12

### DIFF
--- a/MarathonRecomp/gpu/video.cpp
+++ b/MarathonRecomp/gpu/video.cpp
@@ -217,9 +217,9 @@ struct SharedConstants
     uint32_t swappedBlendWeights{};
     float halfPixelOffsetX{};
     float halfPixelOffsetY{};
-    float alphaThreshold{};
-    bool clipPlaneEnabled{};
     float clipPlane[4]{};
+    bool clipPlaneEnabled{};
+    float alphaThreshold{};
 };
 
 // Depth bias values here are only used when the render device has 


### PR DESCRIPTION
Make `g_ClipPlane` not cross constant register boundaries on D3D12.