### PR TITLE
Always optimize included tool submodules.

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,3 +1,13 @@
+option(MARATHON_RECOMP_OPTIMIZE_TOOLS "Apply compiler optimizations to build tools." ON)
+if (MARATHON_RECOMP_OPTIMIZE_TOOLS)
+    if (WIN32)
+        add_compile_options(/O2)
+    else()
+        add_compile_options(-O3)
+    endif()
+    set(CMAKE_INTERPROCEDURAL_OPTIMIZATION ON)
+endif()
+
 add_subdirectory(${MARATHON_RECOMP_TOOLS_ROOT}/bc_diff)
 add_subdirectory(${MARATHON_RECOMP_TOOLS_ROOT}/file_to_c)
 add_subdirectory(${MARATHON_RECOMP_TOOLS_ROOT}/fshasher)


### PR DESCRIPTION
Should improve compile speeds and XEX load speeds in debug builds.

CI: https://github.com/squidbus/MarathonRecomp/actions/runs/16872333128