### PR TITLE
Fix volume config handling.

### DIFF
--- a/MarathonRecomp/app.cpp
+++ b/MarathonRecomp/app.cpp
@@ -20,13 +20,6 @@ void App::Restart(std::vector<std::string> restartArgs)
 
 void App::Exit()
 {
-    // TODO (Hyper): remove this once the new options menu is implemented.
-    if (auto pAudioEngine = Sonicteam::AudioEngineXenon::GetInstance())
-    {
-        Config::MusicVolume = pAudioEngine->m_MusicVolume;
-        Config::EffectsVolume = pAudioEngine->m_EffectsVolume;
-    }
-
     Config::Save();
 
 #ifdef _WIN32

--- a/MarathonRecomp/patches/audio_patches.cpp
+++ b/MarathonRecomp/patches/audio_patches.cpp
@@ -32,6 +32,7 @@ void AudioPatches::Update(float deltaTime)
     if (!pAudioEngine)
         return;
 
+    const float musicVolume = Config::MusicVolume * Config::MasterVolume;
     if (Config::MusicAttenuation && CanAttenuate())
     {
         auto time = 1.0f - expf(2.5f * -deltaTime);
@@ -42,11 +43,11 @@ void AudioPatches::Update(float deltaTime)
         }
         else
         {
-            pAudioEngine->m_MusicVolume = std::lerp(pAudioEngine->m_MusicVolume, Config::MusicVolume, time);
+            pAudioEngine->m_MusicVolume = std::lerp(pAudioEngine->m_MusicVolume, musicVolume, time);
         }
     }
     else
     {
-        pAudioEngine->m_MusicVolume = Config::MusicVolume;
+        pAudioEngine->m_MusicVolume = musicVolume;
     }
 }


### PR DESCRIPTION
* Music attenuation was not taking master volume into account, making music louder than it should be when the master volume is lowered.
* Saving the volume levels to the config was not working properly since again, it did not take into account the master volume adjustment. This is also just broken anyway because of the music attenuation patch overriding whatever music volume you set, so I just removed it completely for now, pending a proper options menu.