### PR TITLE
Fix power up jingle fading in BGM prematurely at HFR

### DIFF
--- a/MarathonRecomp/user/config_def.h
+++ b/MarathonRecomp/user/config_def.h
@@ -77,6 +77,7 @@ CONFIG_DEFINE_HIDDEN("Codes", bool, DisableDWMRoundedCorners, false);
 CONFIG_DEFINE_HIDDEN("Codes", bool, DisableTitleInputDelay, false);
 CONFIG_DEFINE_HIDDEN("Codes", bool, HUDToggleKey, false);
 CONFIG_DEFINE_HIDDEN("Codes", bool, SkipIntroLogos, false);
+CONFIG_DEFINE_HIDDEN("Codes", bool, FixPowerUpJingleDuration, false);
 CONFIG_DEFINE_HIDDEN("Codes", bool, UseOfficialTitleOnTitleBar, false);
 CONFIG_DEFINE_HIDDEN("Codes", bool, DisableLowResolutionFontOnCustomUI, false);
 CONFIG_DEFINE_HIDDEN("Codes", bool, RestoreContextualHUDColours, false);

--- a/MarathonRecompLib/config/Marathon.toml
+++ b/MarathonRecompLib/config/Marathon.toml
@@ -209,3 +209,13 @@ jump_address_on_true = 0x82653840
 name = "PostureControlRotationSpeedFix"
 address = 0x82201C6C
 registers = ["f1", "r1"]
+
+[[midasm_hook]]
+name = "CriCueUpdateDeltaTimeFix"
+address = 0x8260F238
+registers = ["f13"]
+
+[[midasm_hook]]
+name = "PowerUpJingleDurationFix"
+address = 0x8216CC28
+registers = ["f31"]


### PR DESCRIPTION
This PR also adds a new config value to fix the power up jingle duration, since it's 15 seconds instead of 20 seconds and cuts off the end of the song.

Closes https://github.com/sonicnext-dev/MarathonRecomp/issues/119.