### PR TITLE
Remove instancing apart from primitive workarounds

### DIFF
--- a/MarathonRecomp/gpu/video.cpp
+++ b/MarathonRecomp/gpu/video.cpp
@@ -7811,7 +7811,6 @@ public:
                     "{},"
                     "{},"
                     "{},"
-                    "{},"
                     "RenderBlend::{},"
                     "RenderBlend::{},"
                     "RenderCullMode::{},"


### PR DESCRIPTION
06 does not make use of instancing anywhere, and these checks were causing instability on D3D12.