### PR TITLE
Rename additional "Unleashed Recompiled" mentions

### DIFF
--- a/MarathonRecomp/apu/driver/sdl2_driver.cpp
+++ b/MarathonRecomp/apu/driver/sdl2_driver.cpp
@@ -44,7 +44,7 @@ void XAudioInitializeSystem()
 #endif
 
     SDL_SetHint(SDL_HINT_AUDIO_CATEGORY, "playback");
-    SDL_SetHint(SDL_HINT_AUDIO_DEVICE_APP_NAME, "Unleashed Recompiled");
+    SDL_SetHint(SDL_HINT_AUDIO_DEVICE_APP_NAME, "Marathon Recompiled");
 
     if (SDL_InitSubSystem(SDL_INIT_AUDIO) < 0)
     {

--- a/MarathonRecomp/main.cpp
+++ b/MarathonRecomp/main.cpp
@@ -152,7 +152,7 @@ void init()
         printf("[*] CPU does not support the AVX instruction set.\n");
 
 #ifdef _WIN32
-        MessageBoxA(nullptr, "Your CPU does not meet the minimum system requirements.", "Unleashed Recompiled", MB_ICONERROR);
+        MessageBoxA(nullptr, "Your CPU does not meet the minimum system requirements.", "Marathon Recompiled", MB_ICONERROR);
 #endif
 
         std::_Exit(1);

--- a/MarathonRecomp/ui/game_window.cpp
+++ b/MarathonRecomp/ui/game_window.cpp
@@ -189,7 +189,7 @@ void GameWindow::Init(const char* sdlVideoDriver)
     if (!IsPositionValid())
         GameWindow::ResetDimensions();
 
-    s_pWindow = SDL_CreateWindow("Unleashed Recompiled", s_x, s_y, s_width, s_height, GetWindowFlags());
+    s_pWindow = SDL_CreateWindow("Marathon Recompiled", s_x, s_y, s_width, s_height, GetWindowFlags());
 
     if (IsFullscreen())
         SDL_ShowCursor(SDL_DISABLE);


### PR DESCRIPTION
Outside of the README and mod loader file, which has remained unaltered, all other instances of the mention "Unleashed Recompiled" has now been replaced with the appropriate "Marathon Recompiled" title instead.
This should allow avoiding any potential new conflicts with Unleashed Recompiled for the time being, although the future remains uncertain.