### PR TITLE
Point Light Fixes

### DIFF
--- a/MarathonRecomp/patches/misc_patches.cpp
+++ b/MarathonRecomp/patches/misc_patches.cpp
@@ -114,6 +114,4 @@ PPC_FUNC(sub_824A6EA8)
     __imp__sub_824A6EA8(ctx, base);
 }
 
-void SkipSPAABBTree() {}
-
-void SkipUpdateOptimisation() {}
+void NOP() {}

--- a/MarathonRecomp/patches/misc_patches.cpp
+++ b/MarathonRecomp/patches/misc_patches.cpp
@@ -113,3 +113,7 @@ PPC_FUNC(sub_824A6EA8)
 
     __imp__sub_824A6EA8(ctx, base);
 }
+
+void SkipSPAABBTree() {}
+
+void SkipUpdateOptimisation() {}

--- a/MarathonRecompLib/config/Marathon.toml
+++ b/MarathonRecompLib/config/Marathon.toml
@@ -290,42 +290,50 @@ name = "ControllableSpinkick"
 address = 0x821A7A04
 jump_address_on_true = 0x821A7A08
 
+# Skip SPAABBTree initalisation for point light search
 [[midasm_hook]]
-name = "SkipSPAABBTree"
+name = "NOP"
 address = 0x8258DBC4
 jump_address = 0x8258DBE0
 
+# Skip SPAABBTree initalisation for point light search
 [[midasm_hook]]
-name = "SkipSPAABBTree"
+name = "NOP"
 address = 0x8258DF60
 jump_address = 0x8258DF7C
 
+# Skip SPAABBTree initalisation for point light search
 [[midasm_hook]]
-name = "SkipSPAABBTree"
+name = "NOP"
 address = 0x8258E29C
 jump_address = 0x8258E2B8
 
+# Skip SPAABBTree initalisation for point light search
 [[midasm_hook]]
-name = "SkipSPAABBTree"
+name = "NOP"
 address = 0x8258E598
 jump_address = 0x8258E5B4
 
+# Skip point light update optimisation
 [[midasm_hook]]
-name = "SkipUpdateOptimisation"
+name = "NOP"
 address = 0x8258DC28
 jump_address = 0x8258DC2C
 
+# Skip point light update optimisation
 [[midasm_hook]]
-name = "SkipUpdateOptimisation"
+name = "NOP"
 address = 0x8258DFC4
 jump_address = 0x8258DFC8
 
+# Skip point light update optimisation
 [[midasm_hook]]
-name = "SkipUpdateOptimisation"
+name = "NOP"
 address = 0x8258E304
 jump_address = 0x8258E308
 
+# Skip point light update optimisation
 [[midasm_hook]]
-name = "SkipUpdateOptimisation"
+name = "NOP"
 address = 0x8258E600
 jump_address = 0x8258E604

--- a/MarathonRecompLib/config/Marathon.toml
+++ b/MarathonRecompLib/config/Marathon.toml
@@ -290,25 +290,25 @@ name = "ControllableSpinkick"
 address = 0x821A7A04
 jump_address_on_true = 0x821A7A08
 
-# Skip SPAABBTree initalisation for point light search
+# Skip SPAABBTree initialisation for point light search
 [[midasm_hook]]
 name = "NOP"
 address = 0x8258DBC4
 jump_address = 0x8258DBE0
 
-# Skip SPAABBTree initalisation for point light search
+# Skip SPAABBTree initialisation for point light search
 [[midasm_hook]]
 name = "NOP"
 address = 0x8258DF60
 jump_address = 0x8258DF7C
 
-# Skip SPAABBTree initalisation for point light search
+# Skip SPAABBTree initialisation for point light search
 [[midasm_hook]]
 name = "NOP"
 address = 0x8258E29C
 jump_address = 0x8258E2B8
 
-# Skip SPAABBTree initalisation for point light search
+# Skip SPAABBTree initialisation for point light search
 [[midasm_hook]]
 name = "NOP"
 address = 0x8258E598

--- a/MarathonRecompLib/config/Marathon.toml
+++ b/MarathonRecompLib/config/Marathon.toml
@@ -289,3 +289,43 @@ jump_address_on_true = 0x821A2988
 name = "ControllableSpinkick"
 address = 0x821A7A04
 jump_address_on_true = 0x821A7A08
+
+[[midasm_hook]]
+name = "SkipSPAABBTree"
+address = 0x8258DBC4
+jump_address = 0x8258DBE0
+
+[[midasm_hook]]
+name = "SkipSPAABBTree"
+address = 0x8258DF60
+jump_address = 0x8258DF7C
+
+[[midasm_hook]]
+name = "SkipSPAABBTree"
+address = 0x8258E29C
+jump_address = 0x8258E2B8
+
+[[midasm_hook]]
+name = "SkipSPAABBTree"
+address = 0x8258E598
+jump_address = 0x8258E5B4
+
+[[midasm_hook]]
+name = "SkipUpdateOptimisation"
+address = 0x8258DC28
+jump_address = 0x8258DC2C
+
+[[midasm_hook]]
+name = "SkipUpdateOptimisation"
+address = 0x8258DFC4
+jump_address = 0x8258DFC8
+
+[[midasm_hook]]
+name = "SkipUpdateOptimisation"
+address = 0x8258E304
+jump_address = 0x8258E308
+
+[[midasm_hook]]
+name = "SkipUpdateOptimisation"
+address = 0x8258E600
+jump_address = 0x8258E604


### PR DESCRIPTION
This implements numerous fixes for point lights, making them much more consistent than they are in vanilla. Most lights should no longer intermittently flicker.

This still has a couple of issues with some lights and some stages, likely due to the low per-object light limit. I don't fully understand the algorithm that selects lights yet, so I can't speak as to whether it's a mistake in the implementation, or just the engineer running out of light slots, but the next step will be bumping the per-object point light limit, likely to 8 or 16, as that's what the limit is on the CPU side.