### PR TITLE
Fix camera rotation speed at HFR

### DIFF
--- a/MarathonRecomp/api/Sonicteam/Camera/SonicCamera.h
+++ b/MarathonRecomp/api/Sonicteam/Camera/SonicCamera.h
@@ -8,7 +8,8 @@ namespace Sonicteam::Camera
         MARATHON_INSERT_PADDING(0x1C);
         be<float> m_SpringK;
         be<float> m_DampingK;
-        MARATHON_INSERT_PADDING(0x08);
+        be<float> m_AzDamping;
+        be<float> m_AltDamping;
         be<float> m_AzDriveK;
         be<float> m_AzDampingK;
         be<float> m_AltDriveK;

--- a/MarathonRecomp/patches/camera_patches.cpp
+++ b/MarathonRecomp/patches/camera_patches.cpp
@@ -1,18 +1,18 @@
-#include <api/Marathon.h>
 #include <user/config.h>
 
-// Load Sonicteam::Camera::SonicCamera parameters
-PPC_FUNC_IMPL(__imp__sub_82192218);
-PPC_FUNC(sub_82192218)
+void SonicCamera_InvertAzDriveK(PPCRegister& az_driveK)
 {
-    auto pSonicCamera = (Sonicteam::Camera::SonicCamera*)g_memory.Translate(ctx.r3.u32);
-
-    __imp__sub_82192218(ctx, base);
-
     // X axis is inverted by default.
-    if (Config::HorizontalCamera == ECameraRotationMode::Normal)
-        pSonicCamera->m_AzDriveK = -pSonicCamera->m_AzDriveK;
+    if (Config::HorizontalCamera != ECameraRotationMode::Normal)
+        return;
 
-    if (Config::VerticalCamera == ECameraRotationMode::Reverse)
-        pSonicCamera->m_AltDriveK = -pSonicCamera->m_AltDriveK;
+    az_driveK.f64 = -az_driveK.f64;
+}
+
+void SonicCamera_InvertAltDriveK(PPCRegister& alt_driveK)
+{
+    if (Config::VerticalCamera != ECameraRotationMode::Reverse)
+        return;
+
+    alt_driveK.f64 = -alt_driveK.f64;
 }

--- a/MarathonRecomp/patches/fps_patches.cpp
+++ b/MarathonRecomp/patches/fps_patches.cpp
@@ -13,8 +13,13 @@ PPC_FUNC(sub_82587AA8)
     __imp__sub_82587AA8(ctx, base);
 }
 
-void PostureControlRotationSpeedFix(PPCRegister& c_rotation_speed, PPCRegister& stack)
+void PostureControl_RotationSpeedFix(PPCRegister& c_rotation_speed, PPCRegister& stack)
 {
-    double deltaTime = *(be<double>*)g_memory.Translate(stack.u32 + 0x200);
-    c_rotation_speed.f64 = (c_rotation_speed.f64 * (60.0f * deltaTime));
+    auto deltaTime = *(be<double>*)g_memory.Translate(stack.u32 + 0x200);
+    c_rotation_speed.f64 = (c_rotation_speed.f64 * (60.0 * deltaTime));
+}
+
+void SonicCamera_RotationSpeedFix(PPCRegister& f0, PPCRegister& deltaTime, PPCRegister& f13)
+{
+    f0.f64 = float((f0.f64 * (deltaTime.f64 * (1.0 / (deltaTime.f64 * 60.0)))) + f13.f64);
 }

--- a/MarathonRecompLib/config/Marathon.toml
+++ b/MarathonRecompLib/config/Marathon.toml
@@ -201,7 +201,7 @@ address = 0x82311E50
 jump_address_on_true = 0x82311E54
 
 [[midasm_hook]]
-name = "PostureControlRotationSpeedFix"
+name = "PostureControl_RotationSpeedFix"
 address = 0x82201C6C
 registers = ["f1", "r1"]
 
@@ -337,3 +337,25 @@ jump_address = 0x8258E308
 name = "NOP"
 address = 0x8258E600
 jump_address = 0x8258E604
+
+[[midasm_hook]]
+name = "SonicCamera_InvertAzDriveK"
+address = 0x82191D40
+registers = ["f12"]
+
+[[midasm_hook]]
+name = "SonicCamera_InvertAltDriveK"
+address = 0x82191E00
+registers = ["f12"]
+
+[[midasm_hook]]
+name = "SonicCamera_RotationSpeedFix"
+address = 0x82191DA0
+registers = ["f0", "f31", "f13"]
+jump_address = 0x82191DA4
+
+[[midasm_hook]]
+name = "SonicCamera_RotationSpeedFix"
+address = 0x82191E28
+registers = ["f0", "f31", "f13"]
+jump_address = 0x82191E2C


### PR DESCRIPTION
This PR fixes the camera rotation speed at high frame rates and changes the implementation for inverting the camera to do it on frame, allowing the options to be changed on the fly once the options menu is implemented.

Closes https://github.com/sonicnext-dev/MarathonRecomp/issues/35.