### PR TITLE
Add output resolution to video debug window.

### DIFF
--- a/MarathonRecomp/gpu/video.cpp
+++ b/MarathonRecomp/gpu/video.cpp
@@ -2697,6 +2697,9 @@ static void DrawProfiler()
             ImGui::Text("SDL Video Driver: %s", sdlVideoDriver);
 
         ImGui::NewLine();
+        ImGui::Text("Output Resolution: %d x %d", Video::s_viewportWidth, Video::s_viewportHeight);
+
+        ImGui::NewLine();
         ImGui::Checkbox("Show FPS", &Config::ShowFPS.Value);
         ImGui::NewLine();
 


### PR DESCRIPTION
Adds the video output resolution to the Imgui debug panel, to make it easier to confirm the current resolution when debugging / profiling.