### PR TITLE
Fix lens flares not being occluded by geometry.

### DIFF
--- a/MarathonRecomp/CMakeLists.txt
+++ b/MarathonRecomp/CMakeLists.txt
@@ -471,11 +471,11 @@ function(compile_shader FILE_PATH TARGET_NAME)
 endfunction()
 
 function(compile_vertex_shader FILE_PATH)
-    compile_shader(${FILE_PATH} vs_6_0 -fvk-invert-y)
+    compile_shader(${FILE_PATH} vs_6_0 -fvk-invert-y -DMARATHON_RECOMP)
 endfunction()
 
 function(compile_pixel_shader FILE_PATH)
-    compile_shader(${FILE_PATH} ps_6_0)
+    compile_shader(${FILE_PATH} ps_6_0 -DMARATHON_RECOMP)
 endfunction()
 
 compile_pixel_shader(blend_color_alpha_ps)

--- a/MarathonRecomp/gpu/video.h
+++ b/MarathonRecomp/gpu/video.h
@@ -16,6 +16,9 @@
 #define SPEC_CONSTANT_ALPHA_TO_COVERAGE (1 << 3)
 #define SPEC_CONSTANT_REVERSE_Z         (1 << 4)
 
+#define SPEC_CONSTANT_CONDITIONAL_SURVEY    (1 << 5)
+#define SPEC_CONSTANT_CONDITIONAL_RENDERING (1 << 6)
+
 #define LOAD_ZSTD_TEXTURE(name) LoadTexture(decompressZstd(name, name##_uncompressed_size).get(), name##_uncompressed_size)
 
 using namespace plume;

--- a/MarathonRecompLib/CMakeLists.txt
+++ b/MarathonRecompLib/CMakeLists.txt
@@ -55,6 +55,7 @@ target_compile_definitions(XenosRecomp PRIVATE
     XENOS_RECOMP_INPUT=\"${CMAKE_CURRENT_SOURCE_DIR}/private/shader\" 
     XENOS_RECOMP_OUTPUT=\"${CMAKE_CURRENT_SOURCE_DIR}/shader/shader_cache.cpp\"
     XENOS_RECOMP_INCLUDE_INPUT=\"${XENOS_RECOMP_INCLUDE}\"
+    MARATHON_RECOMP
 )
 
 file(GLOB XENOS_RECOMP_SOURCES 


### PR DESCRIPTION
Adds logic for handling conditional survey and conditional rendering states.

When conditional survey is enabled, shaders are given a spec constant telling them to record the number of fragment invocations into a side buffer. When conditional rendering is enabled, this side buffer is used to determine whether to discard fragments.

Additionally, the texture descriptor set max is decreased to 32768, as using the full 65536 was filling the descriptor heap on D3D12 and causing asserts trying to set up the descriptor set for the buffer. I just halved it to still be a nice number since we will never reach that many textures anyway.

Fixes https://github.com/sonicnext-dev/MarathonRecomp/issues/122