### PR TITLE
Rename log type from None to Info

### DIFF
--- a/MarathonRecomp/kernel/io/file_system.cpp
+++ b/MarathonRecomp/kernel/io/file_system.cpp
@@ -387,7 +387,7 @@ uint32_t XWriteFile(FileHandle* hFile, const void* lpBuffer, uint32_t nNumberOfB
 
 std::filesystem::path FileSystem::ResolvePath(const std::string_view& path, bool checkForMods)
 {
-    LOGF_IMPL(Utility, "Game", "Loading file: \"{}\"", path.data());
+    LOGF_UTILITY("Game", "Loading file: \"{}\"", path.data());
     if (checkForMods)
     {
         std::filesystem::path resolvedPath = ModLoader::ResolvePath(path);
@@ -395,7 +395,7 @@ std::filesystem::path FileSystem::ResolvePath(const std::string_view& path, bool
         if (!resolvedPath.empty())
         {
             if (ModLoader::s_isLogTypeConsole)
-                LOGF_IMPL(Utility, "Mod Loader", "Loading file: \"{}\"", reinterpret_cast<const char*>(resolvedPath.u8string().c_str()));
+                LOGF_UTILITY("Mod Loader", "Loading file: \"{}\"", reinterpret_cast<const char*>(resolvedPath.u8string().c_str()));
 
             return resolvedPath;
         }

--- a/MarathonRecomp/mod/mod_loader.cpp
+++ b/MarathonRecomp/mod/mod_loader.cpp
@@ -244,7 +244,7 @@ void ModLoader::Init()
             {
                 if (def->GetName() == codes[i])
                 {
-                    LOGF_IMPL(Utility, "Mod Loader", "Loading code: \"{}\"", codes[i]);
+                    LOGF_UTILITY("Mod Loader", "Loading code: \"{}\"", codes[i]);
                     *(bool*)def->GetValue() = true;
                     break;
                 }

--- a/MarathonRecomp/os/logger.h
+++ b/MarathonRecomp/os/logger.h
@@ -7,7 +7,7 @@
 
 // Function-specific logging.
 
-#define LOG(str)               LOG_IMPL(None, __func__, str)
+#define LOG(str)               LOG_IMPL(Info, __func__, str)
 #define LOG_WARNING(str)       LOG_IMPL(Warning, __func__, str)
 #define LOG_ERROR(str)         LOG_IMPL(Error, __func__, str)
 
@@ -17,7 +17,7 @@
 #define LOG_UTILITY(str)       LOG_IMPL(Utility, __func__, str)
 #endif
 
-#define LOGF(str, ...)         LOGF_IMPL(None, __func__, str, __VA_ARGS__)
+#define LOGF(str, ...)         LOGF_IMPL(Info, __func__, str, __VA_ARGS__)
 #define LOGF_WARNING(str, ...) LOGF_IMPL(Warning, __func__, str, __VA_ARGS__)
 #define LOGF_ERROR(str, ...)   LOGF_IMPL(Error, __func__, str, __VA_ARGS__)
 
@@ -29,7 +29,7 @@
 
 // Non-function-specific logging.
 
-#define LOGN(str)               LOG_IMPL(None, "*", str)
+#define LOGN(str)               LOG_IMPL(Info, "*", str)
 #define LOGN_WARNING(str)       LOG_IMPL(Warning, "*", str)
 #define LOGN_ERROR(str)         LOG_IMPL(Error, "*", str)
 
@@ -39,7 +39,7 @@
 #define LOGN_UTILITY(str)       LOG_IMPL(Utility, "*", str)
 #endif
 
-#define LOGFN(str, ...)         LOGF_IMPL(None, "*", str, __VA_ARGS__)
+#define LOGFN(str, ...)         LOGF_IMPL(Info, "*", str, __VA_ARGS__)
 #define LOGFN_WARNING(str, ...) LOGF_IMPL(Warning, "*", str, __VA_ARGS__)
 #define LOGFN_ERROR(str, ...)   LOGF_IMPL(Error, "*", str, __VA_ARGS__)
 
@@ -53,12 +53,12 @@ namespace os::logger
 {
     enum class ELogType
     {
-        None,
+        Info,
         Utility,
         Warning,
         Error
     };
 
     void Init();
-    void Log(const std::string_view str, ELogType type = ELogType::None, const char* func = nullptr);
+    void Log(const std::string_view str, ELogType type = ELogType::Info, const char* func = nullptr);
 }

--- a/MarathonRecomp/os/logger.h
+++ b/MarathonRecomp/os/logger.h
@@ -2,51 +2,51 @@
 
 #include <source_location>
 
-#define LOG_IMPL(type, func, str)       os::logger::Log(str, os::logger::ELogType::type, func)
-#define LOGF_IMPL(type, func, str, ...) os::logger::Log(fmt::format(str, __VA_ARGS__), os::logger::ELogType::type, func)
+#define LOG_IMPL(type, func, str)       os::logger::Log(str, type, func)
+#define LOGF_IMPL(type, func, str, ...) os::logger::Log(fmt::format(str, __VA_ARGS__), type, func)
 
 // Function-specific logging.
 
-#define LOG(str)               LOG_IMPL(Info, __func__, str)
-#define LOG_WARNING(str)       LOG_IMPL(Warning, __func__, str)
-#define LOG_ERROR(str)         LOG_IMPL(Error, __func__, str)
+#define LOG(str)               LOG_IMPL(os::logger::ELogType::Info, __func__, str)
+#define LOG_WARNING(str)       LOG_IMPL(os::logger::ELogType::Warning, __func__, str)
+#define LOG_ERROR(str)         LOG_IMPL(os::logger::ELogType::Error, __func__, str)
 
 #if _DEBUG
-#define LOG_UTILITY(str)       LOG_IMPL(Utility, __func__, str)
+#define LOG_UTILITY(str)       LOG_IMPL(os::logger::ELogType::Utility, __func__, str)
 #else
-#define LOG_UTILITY(str)       LOG_IMPL(Utility, __func__, str)
+#define LOG_UTILITY(str)       LOG_IMPL(os::logger::ELogType::Utility, __func__, str)
 #endif
 
-#define LOGF(str, ...)         LOGF_IMPL(Info, __func__, str, __VA_ARGS__)
-#define LOGF_WARNING(str, ...) LOGF_IMPL(Warning, __func__, str, __VA_ARGS__)
-#define LOGF_ERROR(str, ...)   LOGF_IMPL(Error, __func__, str, __VA_ARGS__)
+#define LOGF(str, ...)         LOGF_IMPL(os::logger::ELogType::Info, __func__, str, __VA_ARGS__)
+#define LOGF_WARNING(str, ...) LOGF_IMPL(os::logger::ELogType::Warning, __func__, str, __VA_ARGS__)
+#define LOGF_ERROR(str, ...)   LOGF_IMPL(os::logger::ELogType::Error, __func__, str, __VA_ARGS__)
 
 #if _DEBUG
-#define LOGF_UTILITY(str, ...) LOGF_IMPL(Utility, __func__, str, __VA_ARGS__)
+#define LOGF_UTILITY(str, ...) LOGF_IMPL(os::logger::ELogType::Utility, __func__, str, __VA_ARGS__)
 #else
-#define LOGF_UTILITY(str, ...) LOGF_IMPL(Utility, __func__, str, __VA_ARGS__)
+#define LOGF_UTILITY(str, ...) LOGF_IMPL(os::logger::ELogType::Utility, __func__, str, __VA_ARGS__)
 #endif
 
 // Non-function-specific logging.
 
-#define LOGN(str)               LOG_IMPL(Info, "*", str)
-#define LOGN_WARNING(str)       LOG_IMPL(Warning, "*", str)
-#define LOGN_ERROR(str)         LOG_IMPL(Error, "*", str)
+#define LOGN(str)               LOG_IMPL(os::logger::ELogType::Info, "*", str)
+#define LOGN_WARNING(str)       LOG_IMPL(os::logger::ELogType::Warning, "*", str)
+#define LOGN_ERROR(str)         LOG_IMPL(os::logger::ELogType::Error, "*", str)
 
 #if _DEBUG
-#define LOGN_UTILITY(str)       LOG_IMPL(Utility, "*", str)
+#define LOGN_UTILITY(str)       LOG_IMPL(os::logger::ELogType::Utility, "*", str)
 #else
-#define LOGN_UTILITY(str)       LOG_IMPL(Utility, "*", str)
+#define LOGN_UTILITY(str)       LOG_IMPL(os::logger::ELogType::Utility, "*", str)
 #endif
 
-#define LOGFN(str, ...)         LOGF_IMPL(Info, "*", str, __VA_ARGS__)
-#define LOGFN_WARNING(str, ...) LOGF_IMPL(Warning, "*", str, __VA_ARGS__)
-#define LOGFN_ERROR(str, ...)   LOGF_IMPL(Error, "*", str, __VA_ARGS__)
+#define LOGFN(str, ...)         LOGF_IMPL(os::logger::ELogType::Info, "*", str, __VA_ARGS__)
+#define LOGFN_WARNING(str, ...) LOGF_IMPL(os::logger::ELogType::Warning, "*", str, __VA_ARGS__)
+#define LOGFN_ERROR(str, ...)   LOGF_IMPL(os::logger::ELogType::Error, "*", str, __VA_ARGS__)
 
 #if _DEBUG
-#define LOGFN_UTILITY(str, ...) LOGF_IMPL(Utility, "*", str, __VA_ARGS__)
+#define LOGFN_UTILITY(str, ...) LOGF_IMPL(os::logger::ELogType::Utility, "*", str, __VA_ARGS__)
 #else
-#define LOGFN_UTILITY(str, ...) LOGF_IMPL(Utility, "*", str, __VA_ARGS__)
+#define LOGFN_UTILITY(str, ...) LOGF_IMPL(os::logger::ELogType::Utility, "*", str, __VA_ARGS__)
 #endif
 
 namespace os::logger


### PR DESCRIPTION
Fixes #238 by explicitly specifying the log type, as well as renaming `None` type to `Info`, since that is a more appropriate name 